### PR TITLE
Alert panel: add filtering by alert name or dashboard tag.

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -260,6 +260,8 @@ type (
 		SortOrder             int      `json:"sortOrder"`
 		Limit                 int      `json:"limit"`
 		StateFilter           []string `json:"stateFilter"`
+		NameFilter            string   `json:"nameFilter,omitempty"`
+		DashboardTags         []string `json:"dashboardTags,omitempty"`
 	}
 	RowPanel struct {
 		Panels []Panel


### PR DESCRIPTION
Grafana has the ability to filter alerts in the alert-panel:
- based on the name of the alert (substring match)
- based on dashboard tags (which will select alerts from dashboards tagged with any of the given tags)

This PR allows us to set those fields.