### PR TITLE
Introduce sparkline thresholds.

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -234,10 +234,12 @@ type (
 		PrefixFontSize  *string     `json:"prefixFontSize,omitempty"`
 		RangeMaps       []*RangeMap `json:"rangeMaps,omitempty"`
 		SparkLine       struct {
-			FillColor *string `json:"fillColor,omitempty"`
-			Full      bool    `json:"full,omitempty"`
-			LineColor *string `json:"lineColor,omitempty"`
-			Show      bool    `json:"show,omitempty"`
+			FillColor *string  `json:"fillColor,omitempty"`
+			Full      bool     `json:"full,omitempty"`
+			LineColor *string  `json:"lineColor,omitempty"`
+			Show      bool     `json:"show,omitempty"`
+			YMin      *float64 `json:"ymin,omitempty"`
+			YMax      *float64 `json:"ymax,omitempty"`
 		} `json:"sparkline,omitempty"`
 		Targets       []Target   `json:"targets,omitempty"`
 		Thresholds    string     `json:"thresholds"`


### PR DESCRIPTION
The single-stat panel supports thresholds on the sparkline.
If a threshold is absent, the threshold is automatically derived
by grafana, based on the rendered line.