### PR TITLE
Add alert `for` property.

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -116,6 +116,7 @@ type (
 		NoDataState         string              `json:"noDataState,omitempty"`
 		Notifications       []AlertNotification `json:"notifications,omitempty"`
 		Message             string              `json:"message,omitempty"`
+		For                 string              `json:"for,omitempty"`
 	}
 	GraphPanel struct {
 		AliasColors interface{} `json:"aliasColors"` // XXX


### PR DESCRIPTION
Add `for` property that describes how long the alert stays in the pending duration before it starts alerting.