### PR TITLE
export the links struct so we can use it

### DIFF
--- a/board.go
+++ b/board.go
@@ -60,7 +60,7 @@ type (
 		Refresh       *BoolString `json:"refresh,omitempty"`
 		SchemaVersion uint        `json:"schemaVersion"`
 		Version       uint        `json:"version"`
-		Links         []link      `json:"links"`
+		Links         []Link      `json:"links"`
 		Time          Time        `json:"time"`
 		Timepicker    Timepicker  `json:"timepicker"`
 		lastPanelID   uint
@@ -125,8 +125,8 @@ type (
 	}
 )
 
-// link represents link to another dashboard or external weblink
-type link struct {
+// Link represents link to another dashboard or external weblink
+type Link struct {
 	Title       string   `json:"title"`
 	Type        string   `json:"type"`
 	AsDropdown  *bool    `json:"asDropdown,omitempty"`

--- a/panel.go
+++ b/panel.go
@@ -68,7 +68,7 @@ type (
 		HideTimeOverride *bool     `json:"hideTimeOverride,omitempty"`
 		ID               uint      `json:"id"`
 		IsNew            bool      `json:"isNew"`
-		Links            []link    `json:"links,omitempty"`    // general
+		Links            []Link    `json:"links,omitempty"`    // general
 		MinSpan          *float32  `json:"minSpan,omitempty"`  // templating options
 		OfType           panelType `json:"-"`                  // it required for defining type of the panel
 		Renderer         *string   `json:"renderer,omitempty"` // display styles


### PR DESCRIPTION
Right now we can't create links on dashboards since the struct isn't exported. Do that.